### PR TITLE
Implement Keynote::Document.find_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ themes = Theme.find_by(:all)
 theme = Theme.find_by(name: 'ブラック').first
 # #<Keynote::Theme:0x007fd9ec821748 @id="Application/Black/Standard", @name="ブラック">,
 
-doc = Document.new(theme: theme, file_path: '/path/to/foo.key')
+doc = Document.create(theme: theme, file_path: '/path/to/foo.key')
 # => #<Keynote::Document:0x007fbe03224228
 # @auto_loop=false,
 # @auto_play=false,


### PR DESCRIPTION
I want to find `Keynote::Document` in the same way as `Keynote::Theme`.

To provide such an API, `Keynote::Document#initialize` should not create a new document.

```rb
[3] 2.2.2-p95 (main)> Keynote::Document.find_by(id: "D0516A97-93F6-49F7-A3C2-B2EB48B08210")
=> [#<Keynote::Document:0x007fae58a743e8
  @auto_loop=false,
  @auto_play=false,
  @auto_restart=false,
  @current_slide=nil,
  @document_theme=#<Keynote::Theme:0x007fae58a66d38 @id="Application/Black/Standard", @name="ブラック">,
  @file_path=nil,
  @height=768,
  @id="D0516A97-93F6-49F7-A3C2-B2EB48B08210",
  @maximum_idle_duration=15,
  @name="名称未設定",
  @slide_numbers_showing=false,
  @width=1024>]
```