### PR TITLE
Refine method to update slides

### DIFF
--- a/lib/keynote/document.rb
+++ b/lib/keynote/document.rb
@@ -80,8 +80,8 @@ module Keynote
             skipped: slide.skipped(),
             slide_number: slide.slideNumber(),
             title_showing: slide.titleShowing(),
-            default_body_item: slide.defaultBodyItem(),
-            default_title_item: slide.defaultTitleItem(),
+            body: slide.defaultBodyItem.objectText(),
+            title: slide.defaultTitleItem.objectText(),
             presenter_notes: slide.presenterNotes(),
             transition_properties: slide.transitionProperties()
           })
@@ -91,13 +91,14 @@ module Keynote
 
       @slides = results.map do |result|
         Slide.new(
+          document: self,
           base_slide: MasterSlide.new(result["base_slide"]),
           body_showing: result["body_showing"],
           skipped: result["skipped"],
           slide_number: result["slide_number"],
           title_showing: result["title_showing"],
-          default_body_item: result["default_body_item"],
-          default_title_item: result["default_title_item"],
+          body: result["body"],
+          title: result["title"],
           presenter_notes: result["presenter_notes"],
           transition_properties: result["transition_properties"],
         )
@@ -116,14 +117,16 @@ module Keynote
         var slide = Keynote.Slide({ baseSlide: masterSlide })
         doc.slides.push(slide)
         slide = doc.slides()[doc.slides().length - 1]
+        slide.defaultTitleItem.objectText = "#{arguments[:title]}"
+        slide.defaultBodyItem.objectText = "#{arguments[:body]}"
 
         var slideResult = {
           body_showing: slide.bodyShowing(),
           skipped: slide.skipped(),
           slide_number: slide.slideNumber(),
           title_showing: slide.titleShowing(),
-          default_body_item: slide.defaultBodyItem(),
-          default_title_item: slide.defaultTitleItem(),
+          body: slide.defaultBodyItem.objectText(),
+          title: slide.defaultTitleItem.objectText(),
           presenter_notes: slide.presenterNotes(),
           transition_properties: slide.transitionProperties()
         }
@@ -136,8 +139,8 @@ module Keynote
         skipped: result["skipped"],
         slide_number: result["slide_number"],
         title_showing: result["title_showing"],
-        default_body_item: result["default_body_item"],
-        default_title_item: result["default_title_item"],
+        body: result["body"],
+        title: result["title"],
         presenter_notes: result["presenter_notes"],
         transition_properties: result["transition_properties"],
       )

--- a/lib/keynote/slide.rb
+++ b/lib/keynote/slide.rb
@@ -19,7 +19,8 @@ module Keynote
       :transition_properties,
     )
 
-    def initialize(arguments = {})
+    def initialize(base_slide, arguments = {})
+      @base_slide = base_slide
       arguments.each do |attr, val|
         send("#{attr}=", val)
       end

--- a/lib/keynote/slide.rb
+++ b/lib/keynote/slide.rb
@@ -7,14 +7,14 @@ module Keynote
     include Keynote::Util
 
     attr_accessor(
-      :id,
+      :document,
       :base_slide,
       :body_showing,
       :skipped,
       :slide_number,
       :title_showing,
-      :default_body_item,
-      :default_title_item,
+      :body,
+      :title,
       :presenter_notes,
       :transition_properties,
     )
@@ -23,6 +23,32 @@ module Keynote
       arguments.each do |attr, val|
         send("#{attr}=", val)
       end
+    end
+
+    def title=(title)
+      @title = title
+      return unless @document
+      return unless @slide_number
+      result = eval_script <<-APPLE.unindent
+        var Keynote = Application("Keynote")
+        var doc = Keynote.documents.byId("#{@document.id}")
+        var slide = doc.slides()[#{@slide_number - 1}]
+        slide.defaultTitleItem.objectText = "#{title}"
+        JSON.stringify({ result: true })
+      APPLE
+    end
+
+    def body=(body)
+      @body = body
+      return unless @document
+      return unless @slide_number
+      result = eval_script <<-APPLE.unindent
+        var Keynote = Application("Keynote")
+        var doc = Keynote.documents.byId("#{@document.id}")
+        var slide = doc.slides()[#{@slide_number - 1}]
+        slide.defaultBodyItem.objectText = "#{body}"
+        JSON.stringify({ result: true })
+      APPLE
     end
   end
 end

--- a/lib/keynote/slide_array.rb
+++ b/lib/keynote/slide_array.rb
@@ -1,0 +1,53 @@
+require 'unindent'
+require 'keynote/util'
+
+module Keynote
+  module ArrayMethods
+    def <<(slide)
+      raise ArgumentError.new "master_slide_name is not specified" unless slide.base_slide
+
+      title = slide.title.gsub(/(\r\n|\r|\n)/) { '\\n' }
+      body  = slide.body.gsub(/(\r\n|\r|\n)/) { '\\n' }
+
+      result = eval_script <<-APPLE.unindent
+        var Keynote = Application("Keynote")
+        var doc = Keynote.documents.byId("#{self.document.id}")
+        var masterSlide = doc.masterSlides.whose({name: "#{slide.base_slide}"}).first
+        var slide = Keynote.Slide({ baseSlide: masterSlide })
+        doc.slides.push(slide)
+        slide = doc.slides()[doc.slides().length - 1]
+        slide.defaultTitleItem.objectText = "#{title}"
+        slide.defaultBodyItem.objectText = "#{body}"
+
+        var slideResult = {
+          body_showing: slide.bodyShowing(),
+          skipped: slide.skipped(),
+          slide_number: slide.slideNumber(),
+          title_showing: slide.titleShowing(),
+          body: slide.defaultBodyItem.objectText(),
+          title: slide.defaultTitleItem.objectText(),
+          presenter_notes: slide.presenterNotes(),
+          transition_properties: slide.transitionProperties()
+        }
+        JSON.stringify(slideResult)
+      APPLE
+
+      slide.document = self.document
+      slide.body_showing = result["body_showing"]
+      slide.skipped = result["skipped"]
+      slide.slide_number = result["slide_number"]
+      slide.title_showing = result["title_showing"]
+      slide.presenter_notes = result["presenter_notes"]
+      slide.transition_properties = result["transition_properties"]
+
+      super
+    end
+  end
+
+  class SlideArray < Array
+    prepend ArrayMethods
+    attr_accessor :document
+
+    include Keynote::Util
+  end
+end


### PR DESCRIPTION
This PR refines methods to update slides.

```ruby
include Keynote

doc = Document.new
slide = Slide.new(
  "タイトル & 箇条書き",
  title: 'About pen',
  body: "Is This is a pen?\nYes, it's a pen."
)

# Append a new slide
doc.slides << slide

slide = doc.slides.last

# Update slide title
slide.title = 'About this pen'
# Update slide body
slide.title = 'Hello, pen.'
```

And PR removes `Document#append_slide`.