### PR TITLE
Change API from `.find_by(:all)` to `.all`

### DIFF
--- a/lib/keynote/document.rb
+++ b/lib/keynote/document.rb
@@ -148,17 +148,33 @@ module Keynote
       self.new(symbolize_keys(result).merge(theme: theme, width: width, height: height))
     end
 
+    def self.all
+      self.find_with_conditions
+    end
+
     def self.find_by(args)
       raise ArgumentError.new('nil argument is given') unless args
 
       if args.is_a?(Hash) && args.has_key?(:id)
         conditions = ".whose({ id: '#{args[:id]}' })"
-      elsif args == :all
-        conditions = ''
       else
         raise ArgumentError.new('Unsupported argument is given')
       end
 
+      find_with_conditions(conditions)
+    end
+
+    def self.current
+      self.all.first
+    end
+
+    private
+
+    def self.symbolize_keys(hash)
+      Hash[hash.map { |k, v| [k.to_sym, v] }]
+    end
+
+    def self.find_with_conditions(conditions = '')
       results = eval_script <<-APPLE.unindent
         var documents = Application("Keynote").documents#{conditions};
         var results = [];
@@ -173,16 +189,6 @@ module Keynote
       results.map do |result|
         self.new(symbolize_keys(result))
       end
-    end
-
-    def self.current
-      self.find_by(:all).first
-    end
-
-    private
-
-    def self.symbolize_keys(hash)
-      Hash[hash.map { |k, v| [k.to_sym, v] }]
     end
   end
 end

--- a/lib/keynote/theme.rb
+++ b/lib/keynote/theme.rb
@@ -13,7 +13,11 @@ module Keynote
     end
 
     def self.default
-      self.find_by(:all).first
+      self.all.first
+    end
+
+    def self.all
+      self.find_with_conditions
     end
 
     def self.find_by(args)
@@ -21,12 +25,16 @@ module Keynote
 
       if args.is_a?(Hash) && args.has_key?(:name)
         conditions = ".whose({ name: '#{args[:name]}' })"
-      elsif args == :all
-        conditions = ''
       else
         raise ArgumentError.new('Unsupported argument is given')
       end
 
+      find_with_conditions(conditions)
+    end
+
+    private
+
+    def self.find_with_conditions(conditions = '')
       results = eval_script <<-APPLE.unindent
         var themes = Application("Keynote").themes#{conditions};
         var results = [];


### PR DESCRIPTION
This PR changes API according to Rails4 style.

- `Document.find_by(:all)` and `Theme.find_by(:all)` is changed to `Document.all` and `Theme.all`
- `find_by` methods does not accept `:all` argument

