### PR TITLE
make sample code in README executable (partially)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ gem install keynote-client
 
 ```ruby
 require 'keynote-client'
-inlude Keynote
+include Keynote
 
 # Fetch all themes
 themes = Theme.all

--- a/lib/keynote/document.rb
+++ b/lib/keynote/document.rb
@@ -136,6 +136,7 @@ module Keynote
       theme = arguments[:theme] || Theme.default
       width = arguments[:wide] ? WIDE_WIDTH : DEFAULT_WIDTH
       height = arguments[:wide] ? WIDE_HEIGHT : DEFAULT_HEIGHT
+      file_path = arguments[:file_path]
 
       result = eval_script <<-APPLE.unindent
         var Keynote = Application("Keynote")
@@ -145,7 +146,7 @@ module Keynote
         JSON.stringify(doc.properties());
       APPLE
 
-      self.new(symbolize_keys(result).merge(theme: theme, width: width, height: height))
+      self.new(symbolize_keys(result).merge(theme: theme, width: width, height: height, file_path: file_path))
     end
 
     def self.all


### PR DESCRIPTION
Great gem!

I fixed 2 tiny bugs which made your sample code causes errors.
I'm still getting an error at `Keynote::ArrayMethods#<<`, but I'm not sure it's because my MacOS is Yosemite or not. (`eval_script` returns `nil`)

Looking forward the v1.0.0 release ;-)