### PR TITLE
Escape new-line char on Slide#title= and Slide#body=

### DIFF
--- a/lib/keynote/slide.rb
+++ b/lib/keynote/slide.rb
@@ -28,6 +28,7 @@ module Keynote
     end
 
     def title=(title)
+      title = title.gsub(/(\r\n|\r|\n)/) { '\\n' }
       @title = title
       return unless @document && @slide_number
 
@@ -41,6 +42,7 @@ module Keynote
     end
 
     def body=(body)
+      body = body.gsub(/(\r\n|\r|\n)/) { '\\n' }
       @body = body
       return unless @document && @slide_number
 

--- a/spec/keynote/slide_spec.rb
+++ b/spec/keynote/slide_spec.rb
@@ -56,7 +56,9 @@ describe Keynote::Slide do
   end
 
   describe '#body=' do
-    subject { slide.body=('new_body') }
+    subject { slide.body=(new_body) }
+
+    let(:new_body) { 'new_body' }
 
     context 'when document is not set' do
       let(:slide) { described_class.new('base_slide') }
@@ -84,11 +86,22 @@ describe Keynote::Slide do
         )
       end
 
-      it 'does not eval script to update Keynote' do
+      it 'evals script to update Keynote' do
         allow(Open3).to receive(:capture2).with(/osascript -l JavaScript/).and_return(["", 1])
         expect(slide).to receive(:eval_script).with(/new_body/)
         subject
         expect(slide.body).to eq('new_body')
+      end
+
+      context 'and when new_body includes new-line character' do
+        let(:new_body) { 'new\nbody' }
+
+        it 'evals script to update Keynote with escaped new body' do
+          allow(Open3).to receive(:capture2).with(/osascript -l JavaScript/).and_return(["", 1])
+          expect(slide).to receive(:eval_script).with(/new\\nbody/)
+          subject
+          expect(slide.body).to eq('new\\nbody')
+        end
       end
     end
   end


### PR DESCRIPTION
This PR escapes new-line character when it is given to `Slide#title=` or `Slide#body`.
This background is [comment by @nov](https://github.com/katsuma/keynote-client/pull/5#issuecomment-162408759).

## spec
```spec
Keynote::Slide
  #body=
    when document is set
      evals script to update Keynote
      and when new_body includes new-line character
        evals script to update Keynote with escaped new body
```